### PR TITLE
chore(frontend): fix legacy peer dependency error

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
This PR fix peer dependency error when installing frontend dependencies